### PR TITLE
Display all past interviews and simplify prompt creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ bundle.js
 apiKey.js
 apiNotes.js
 
-tiHistory.js
+staticTiHistory.js

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -145,11 +145,26 @@ class App extends Component {
     const path = 'https://sheets.googleapis.com/v4/spreadsheets/' +
       '1ObVQGqm894fzjeM5vcG2qysYKDng4g8rtgyIwS3vJh8' +
       '?ranges=%27Form%20Responses%27&includeGridData=true';
-    const { result: { sheets: [sheet] } } = await gapi.client.request({ path });
+    const data = await gapi.client.request({ path });
+    const liveTiRows = this.processLiveTiData(data, email);
+    const staticTiRows = searchStaticTiHistory(email);
+    this.setState({ staticTiRows, liveTiRows });
+  };
+
+  formatLiveTiRow = row => {
+    const unwrappedValues = row.map(cell => cell.formattedValue);
+    const time = moment(unwrappedValues[0]).format('MMMM Do YYYY');
+    const status = unwrappedValues[5];
+    const prompt = unwrappedValues[10];
+    return [time, status, prompt].filter(el => el).join(', ');
+  };
+
+  processLiveTiData = (data, email) => {
+    const { result: { sheets: [sheet] } } = data;
     const { data: [{ rowData : rows }]} = sheet;
     // The sheet has a number of empty rows at the bottom,
     // which .filter would needlessly iterate through.
-    const liveTiRows = [];
+    const unformattedLiveTiRows = [];
     for (let i = 0; i < rows.length; i++) {
       const { values } = rows[i];
       // Empty cells are empty objects, so we can't just check truthiness.
@@ -157,13 +172,12 @@ class App extends Component {
         break;
       }
 
-      const rowEmail = values[4].effectiveValue.stringValue;
+      const rowEmail = values[4].formattedValue;
       if (rowEmail.trim() === email.trim()) { // No misleading whitespace
-        liveTiRows.push(values);
+        unformattedLiveTiRows.push(values);
       }
     }
-    const staticTiRows = searchStaticTiHistory(email);
-    this.setState({ staticTiRows, liveTiRows });
+    return unformattedLiveTiRows.map(this.formatLiveTiRow);
   };
 
   handleLogin = (loggingIn = true) => {

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -5,6 +5,7 @@ import Prompt from './Prompt';
 import Setup from './Setup';
 import apiKey from '../../apiKey.js';
 import searchStaticTiHistory from './searchStaticTiHistory.js';
+import searchLiveTiHistory from './searchLiveTiHistory.js';
 
 class App extends Component {
   state = {
@@ -46,7 +47,7 @@ class App extends Component {
     });
   }
 
-  copyPrompt = async (event) => {
+  copyPrompt = async event => {
     this.setState({ promptSelected: true, suggestedPrompt: '' });
     const promptName = event.target.id;
     const promptId = {
@@ -149,45 +150,12 @@ class App extends Component {
   };
 
   getPrevInterviews = async email => {
-    const path = 'https://sheets.googleapis.com/v4/spreadsheets/' +
-      '1ObVQGqm894fzjeM5vcG2qysYKDng4g8rtgyIwS3vJh8' +
-      '?ranges=%27Form%20Responses%27&includeGridData=true';
-    const data = await gapi.client.request({ path });
-    const liveTiRows = this.processLiveTiData(data, email);
     const staticTiRows = searchStaticTiHistory(email);
+    const liveTiRows = await searchLiveTiHistory(email);
     const allRecords = (liveTiRows.join('') + staticTiRows.join('')).toLowerCase();
     const suggestedPrompt = !allRecords.includes('version') ? 'Version Control'
       : !allRecords.includes('mrp') ? 'MRP' : 'Book Library';
     this.setState({ staticTiRows, liveTiRows, suggestedPrompt });
-  };
-
-  formatLiveTiRow = row => {
-    const unwrappedValues = row.map(cell => cell.formattedValue);
-    const time = moment(unwrappedValues[0]).format('MMMM Do YYYY');
-    const status = unwrappedValues[5];
-    const prompt = unwrappedValues[10];
-    return [time, status, prompt].filter(el => el).join(', ');
-  };
-
-  processLiveTiData = (data, email) => {
-    const { result: { sheets: [sheet] } } = data;
-    const { data: [{ rowData : rows }]} = sheet;
-    // The sheet has a number of empty rows at the bottom,
-    // which .filter would needlessly iterate through.
-    const unformattedLiveTiRows = [];
-    for (let i = 0; i < rows.length; i++) {
-      const { values } = rows[i];
-      // Empty cells are empty objects, so we can't just check truthiness.
-      if (!Object.keys(values[0]).length) { // If we're past the filled rows
-        break;
-      }
-
-      const rowEmail = values[4].formattedValue;
-      if (rowEmail.trim() === email.trim()) { // No misleading whitespace
-        unformattedLiveTiRows.push(values);
-      }
-    }
-    return unformattedLiveTiRows.map(this.formatLiveTiRow);
   };
 
   handleLogin = (loggingIn = true) => {

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -55,12 +55,18 @@ class App extends Component {
       'Book Library': '1dDybGPnNcNr3kE9rJMB-_MmQAtFCTujCFauD0KrPNfY',
     }[promptName];
     try {
+      const { result: { files: [{id: monthFolder }] } } = await gapi.client.request({
+        path: 'https://www.googleapis.com/drive/v3/files',
+        params: {
+          q: `parents in '0B5_RJCdGH93GdW1fMWMzQlg3VEE' and name contains '${moment().format('MMMM YYYY')} - Interview Notes'`,
+        },
+      });
       const copyMetadata = await gapi.client.request({
         path: `https://www.googleapis.com/drive/v3/files/${promptId}/copy`,
         method: 'POST',
         body: {
           name: `${this.state.candidateName} - ${moment().format('YYYY-MM-DD')} - ${promptName}`,
-          parents: ['root'],
+          parents: [monthFolder],
         },
       });
       const copyId = copyMetadata.result.id;

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -3,9 +3,9 @@ import moment from 'moment';
 import Notes from './Notes';
 import Prompt from './Prompt';
 import Setup from './Setup';
-import apiKey from '../../apiKey.js';
-import searchStaticTiHistory from './searchStaticTiHistory.js';
-import searchLiveTiHistory from './searchLiveTiHistory.js';
+import apiKey from '../../apiKey';
+import searchStaticTiHistory from './searchStaticTiHistory';
+import searchLiveTiHistory from './searchLiveTiHistory';
 
 class App extends Component {
   state = {
@@ -56,7 +56,7 @@ class App extends Component {
       'Book Library': '1dDybGPnNcNr3kE9rJMB-_MmQAtFCTujCFauD0KrPNfY',
     }[promptName];
     try {
-      const { result: { files: [{id: monthFolder }] } } = await gapi.client.request({
+      const { result: { files: [{ id: monthFolder }] } } = await gapi.client.request({
         path: 'https://www.googleapis.com/drive/v3/files',
         params: {
           q: `parents in '0B5_RJCdGH93GdW1fMWMzQlg3VEE' and name contains '${moment().format('MMMM YYYY')} - Interview Notes'`,

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -45,9 +45,9 @@ class App extends Component {
     });
   }
 
-  copyPrompt = async event => {
+  copyPrompt = async (event, prompt) => {
     this.setState({ promptSelected: true });
-    const promptName = event.target.id;
+    const promptName = prompt || event.target.id;
     const promptId = {
       'Version Control': '1tTkmIotuBEP8PwvpxmTaTHKDDUCb8i0ikmTfm8D8oA4',
       'MRP': '196ClAKfTFgO8gWs3O57QGcddVnWiS9RNtAXpVuEcrxU',
@@ -149,6 +149,10 @@ class App extends Component {
     const liveTiRows = this.processLiveTiData(data, email);
     const staticTiRows = searchStaticTiHistory(email);
     this.setState({ staticTiRows, liveTiRows });
+    const allRecords = (liveTiRows.join('') + staticTiRows.join('')).toLowerCase();
+    const prompt = !allRecords.includes('version') ? 'Version Control'
+      : !allRecords.includes('mrp') ? 'MRP' : 'Book Library';
+    this.copyPrompt(null, prompt);
   };
 
   formatLiveTiRow = row => {

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -4,7 +4,7 @@ import Notes from './Notes';
 import Prompt from './Prompt';
 import Setup from './Setup';
 import apiKey from '../../apiKey.js';
-import searchStaticTiHistory from 'searchStaticTiHistory.js';
+import searchStaticTiHistory from './searchStaticTiHistory.js';
 
 class App extends Component {
   state = {
@@ -19,6 +19,8 @@ class App extends Component {
     },
     promptUrl: '',
     promptSelected: false,
+    staticTiRows: null,
+    liveTiRows: null,
   };
 
   componentDidMount() {
@@ -147,7 +149,7 @@ class App extends Component {
     const { data: [{ rowData : rows }]} = sheet;
     // The sheet has a number of empty rows at the bottom,
     // which .filter would needlessly iterate through.
-    const matchingRows = [];
+    const liveTiRows = [];
     for (let i = 0; i < rows.length; i++) {
       const { values } = rows[i];
       // Empty cells are empty objects, so we can't just check truthiness.
@@ -157,10 +159,11 @@ class App extends Component {
 
       const rowEmail = values[4].effectiveValue.stringValue;
       if (rowEmail.trim() === email.trim()) { // No misleading whitespace
-        matchingRows.push(values);
+        liveTiRows.push(values);
       }
     }
-    console.log(matchingRows);
+    const staticTiRows = searchStaticTiHistory(email);
+    this.setState({ staticTiRows, liveTiRows });
   };
 
   handleLogin = (loggingIn = true) => {
@@ -212,6 +215,8 @@ class App extends Component {
       rooms,
       promptUrl,
       promptSelected,
+      staticTiRows,
+      liveTiRows,
     } =  this.state;
     const {
       copyPrompt,
@@ -224,7 +229,18 @@ class App extends Component {
         <h1> HR Interview Noter </h1>
 
         <Setup
-          {...{ login, loggedIn, logout, startTime, candidateName, candidateEmail, rooms, setRoom }}
+          {...{
+            login,
+            loggedIn,
+            logout,
+            startTime,
+            candidateName,
+            candidateEmail,
+            staticTiRows,
+            liveTiRows,
+            rooms,
+            setRoom
+          }}
         />
         <br />
         <Prompt

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -19,6 +19,7 @@ class App extends Component {
     },
     promptUrl: '',
     promptSelected: false,
+    suggestedPrompt: '',
     staticTiRows: null,
     liveTiRows: null,
   };
@@ -45,9 +46,9 @@ class App extends Component {
     });
   }
 
-  copyPrompt = async (event, prompt) => {
-    this.setState({ promptSelected: true });
-    const promptName = prompt || event.target.id;
+  copyPrompt = async (event) => {
+    this.setState({ promptSelected: true, suggestedPrompt: '' });
+    const promptName = event.target.id;
     const promptId = {
       'Version Control': '1tTkmIotuBEP8PwvpxmTaTHKDDUCb8i0ikmTfm8D8oA4',
       'MRP': '196ClAKfTFgO8gWs3O57QGcddVnWiS9RNtAXpVuEcrxU',
@@ -148,11 +149,10 @@ class App extends Component {
     const data = await gapi.client.request({ path });
     const liveTiRows = this.processLiveTiData(data, email);
     const staticTiRows = searchStaticTiHistory(email);
-    this.setState({ staticTiRows, liveTiRows });
     const allRecords = (liveTiRows.join('') + staticTiRows.join('')).toLowerCase();
-    const prompt = !allRecords.includes('version') ? 'Version Control'
+    const suggestedPrompt = !allRecords.includes('version') ? 'Version Control'
       : !allRecords.includes('mrp') ? 'MRP' : 'Book Library';
-    this.copyPrompt(null, prompt);
+    this.setState({ staticTiRows, liveTiRows, suggestedPrompt });
   };
 
   formatLiveTiRow = row => {
@@ -233,6 +233,7 @@ class App extends Component {
       rooms,
       promptUrl,
       promptSelected,
+      suggestedPrompt,
       staticTiRows,
       liveTiRows,
     } =  this.state;
@@ -257,7 +258,9 @@ class App extends Component {
             staticTiRows,
             liveTiRows,
             rooms,
-            setRoom
+            setRoom,
+            suggestedPrompt,
+            copyPrompt,
           }}
         />
         <br />

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -4,6 +4,7 @@ import Notes from './Notes';
 import Prompt from './Prompt';
 import Setup from './Setup';
 import apiKey from '../../apiKey.js';
+import searchStaticTiHistory from 'searchStaticTiHistory.js';
 
 class App extends Component {
   state = {

--- a/client/components/Notes.jsx
+++ b/client/components/Notes.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import SectionTitle from './SectionTitle';
-const { countHP, formatNotes } = require('./noteFns');
+import { countHP, formatNotes } from './noteFns';
 
 // ({ show, toggleShow, text, horsepower, autonomy, handleKeyDown, handleNoteChange })
 class Notes extends Component {

--- a/client/components/Setup.jsx
+++ b/client/components/Setup.jsx
@@ -42,6 +42,8 @@ class Setup extends Component {
         zoom,
       },
       setRoom,
+      suggestedPrompt,
+      copyPrompt,
     } = this.props;
     const currentDate = moment().format('YYYY-MM-DD');
 
@@ -61,7 +63,16 @@ class Setup extends Component {
                   `Checking if you're logged in...`} 
               </div> }
             <Steps 
-              {...{ candidateName, candidateEmail, currentDate, tlkio, staticTiRows, liveTiRows }}
+              {...{
+                candidateName,
+                candidateEmail,
+                currentDate,
+                tlkio,
+                staticTiRows,
+                liveTiRows,
+                suggestedPrompt,
+                copyPrompt,
+              }}
             />
             <Input name="tlkio" setter={setRoom} value={tlkio}/>
             <Input name="codestitch" setter={setRoom} />

--- a/client/components/Setup.jsx
+++ b/client/components/Setup.jsx
@@ -34,6 +34,8 @@ class Setup extends Component {
       startTime,
       candidateName,
       candidateEmail,
+      staticTiRows,
+      liveTiRows,
       rooms: {
         tlkio,
         codestitch,
@@ -59,7 +61,7 @@ class Setup extends Component {
                   `Checking if you're logged in...`} 
               </div> }
             <Steps 
-              {...{ candidateName, candidateEmail, currentDate, tlkio }}
+              {...{ candidateName, candidateEmail, currentDate, tlkio, staticTiRows, liveTiRows }}
             />
             <Input name="tlkio" setter={setRoom} value={tlkio}/>
             <Input name="codestitch" setter={setRoom} />

--- a/client/components/Steps.jsx
+++ b/client/components/Steps.jsx
@@ -10,12 +10,12 @@ const Steps = ({ candidateName, candidateEmail, currentDate, tlkio, staticTiRows
     <li>Search for {candidateEmail || 'the candidate\'s email'} in the <a href={decisionsUrl} target="_blank">Form Responses</a> spreadsheet.</li>
       {staticTiRows ?
         <ul>Interviews scheduled by {candidateName.split(' ')[0] || 'candidate'} before 6/27/18:
-          {staticTiRows.length ? staticTiRows.map(str => <li>{str}</li>) : ' None.'}
+          {staticTiRows.length ? staticTiRows.map(str => <li key={str}>{str}</li>) : ' None.'}
         </ul>
       : null }
       {liveTiRows ?
-        <ul>Interviews scheduled since 6/27/18:
-          {liveTiRows.length ? liveTiRows.map(str => <li>{str}</li>) : ' None.'}
+        <ul>Interviews scheduled by {candidateName.split(' ')[0] || 'candidate'} since 6/27/18:
+          {liveTiRows.length ? liveTiRows.map(str => <li key={str}>{str}</li>) : ' None.'}
         </ul>
       : null}
     <li>Choose the first prompt they haven't gotten under 'Prompt' below.</li>

--- a/client/components/Steps.jsx
+++ b/client/components/Steps.jsx
@@ -1,7 +1,5 @@
 const decisionsUrl = 'https://docs.google.com/spreadsheets/d/1ObVQGqm894fzjeM5vcG2qysYKDng4g8rtgyIwS3vJh8/edit#gid=391982378';
 const codestitchUrl = 'https://codestitch.io';
-const myDriveUrl = 'https://drive.google.com/drive/my-drive';
-const monthFoldersUrl = 'https://drive.google.com/drive/folders/0B5_RJCdGH93GdW1fMWMzQlg3VEE';
 const tiDecisionsUrl = 'https://goo.gl/forms/IODn7sw3jtpiUq2n1';
 const tiWorkflowUrl = 'https://docs.google.com/document/d/18AJkthUSgu40QUYwQNdQ3B23SIFMVSU5HDr_5bVaCws/edit';
 

--- a/client/components/Steps.jsx
+++ b/client/components/Steps.jsx
@@ -22,13 +22,12 @@ const Steps = ({ candidateName, candidateEmail, currentDate, tlkio, staticTiRows
         <ul>It looks like they haven't used {suggestedPrompt}.&nbsp; 
           <a href="#" id={suggestedPrompt} onClick={copyPrompt}>
               Use {suggestedPrompt}
-          </a>, or choose a prompt below.
+          </a>, or choose a prompt below. It will save to this month's folder.
         </ul>
         : null }
     <li>Open up a <a href={codestitchUrl} target="_blank">Codestitch</a> pad and paste the URL below.</li>
     <li>Schedule a Zoom call named <i>{candidateName || 'FIRSTNAME LASTNAME'} - {currentDate}</i> and paste the join link below.</li>
     <li>Go to <a href={tlkio} target="_blank">the tlk.io link</a> and conduct the interview using the script snippets below.</li>
-    <li>Move the completed prompt document from <a href={myDriveUrl} target="_blank">My Drive</a> to <a href={monthFoldersUrl} target="_blank">this month's folder</a>.</li>
     <li>Fill out the <a href={tiDecisionsUrl} target="_blank">Technical Interview Decisions Form</a>.</li>
     <li>If you have any questions, reference the <a href={tiWorkflowUrl} target="_blank">TI Workflow</a>.</li>
   </ol>

--- a/client/components/Steps.jsx
+++ b/client/components/Steps.jsx
@@ -5,9 +5,9 @@ const monthFoldersUrl = 'https://drive.google.com/drive/folders/0B5_RJCdGH93GdW1
 const tiDecisionsUrl = 'https://goo.gl/forms/IODn7sw3jtpiUq2n1';
 const tiWorkflowUrl = 'https://docs.google.com/document/d/18AJkthUSgu40QUYwQNdQ3B23SIFMVSU5HDr_5bVaCws/edit';
 
-const Steps = ({ candidateName, candidateEmail, currentDate, tlkio, staticTiRows, liveTiRows }) => (
+const Steps = ({ candidateName, candidateEmail, currentDate, tlkio, staticTiRows, liveTiRows, suggestedPrompt, copyPrompt, }) => (
   <ol>
-    <li>Search for {candidateEmail || 'the candidate\'s email'} in the <a href={decisionsUrl} target="_blank">Form Responses</a> spreadsheet.</li>
+    <li>Records for {candidateEmail || 'the candidate\'s email'} in the <a href={decisionsUrl} target="_blank">Technical Interview Decisions</a> spreadsheet:</li>
       {staticTiRows ?
         <ul>Interviews scheduled by {candidateName.split(' ')[0] || 'candidate'} before 6/27/18:
           {staticTiRows.length ? staticTiRows.map(str => <li key={str}>{str}</li>) : ' None.'}
@@ -18,7 +18,13 @@ const Steps = ({ candidateName, candidateEmail, currentDate, tlkio, staticTiRows
           {liveTiRows.length ? liveTiRows.map(str => <li key={str}>{str}</li>) : ' None.'}
         </ul>
       : null}
-    <li>Choose the first prompt they haven't gotten under 'Prompt' below.</li>
+      {suggestedPrompt ? 
+        <ul>It looks like they haven't used {suggestedPrompt}.&nbsp; 
+          <a href="#" id={suggestedPrompt} onClick={copyPrompt}>
+              Use {suggestedPrompt}
+          </a>, or choose a prompt below.
+        </ul>
+        : null }
     <li>Open up a <a href={codestitchUrl} target="_blank">Codestitch</a> pad and paste the URL below.</li>
     <li>Schedule a Zoom call named <i>{candidateName || 'FIRSTNAME LASTNAME'} - {currentDate}</i> and paste the join link below.</li>
     <li>Go to <a href={tlkio} target="_blank">the tlk.io link</a> and conduct the interview using the script snippets below.</li>

--- a/client/components/Steps.jsx
+++ b/client/components/Steps.jsx
@@ -1,15 +1,3 @@
-import tiHistory from '../../tiHistory.js';
-import moment from 'moment';
-
-const tiRows = tiHistory.split('\n').map(row => row.split(','));
-const searchTiRows = email => tiRows
-  .filter(([, rowEmail]) => rowEmail === (email || null));
-const formatRow = row => {
-  const [, , time, status, prompt] = row;
-  const formattedTime = moment(time).format('MMMM Do YYYY');
-  return [formattedTime, status, prompt].filter(el => el).join(', ');
-};
-
 const decisionsUrl = 'https://docs.google.com/spreadsheets/d/1ObVQGqm894fzjeM5vcG2qysYKDng4g8rtgyIwS3vJh8/edit#gid=391982378';
 const codestitchUrl = 'https://codestitch.io';
 const myDriveUrl = 'https://drive.google.com/drive/my-drive';
@@ -17,23 +5,20 @@ const monthFoldersUrl = 'https://drive.google.com/drive/folders/0B5_RJCdGH93GdW1
 const tiDecisionsUrl = 'https://goo.gl/forms/IODn7sw3jtpiUq2n1';
 const tiWorkflowUrl = 'https://docs.google.com/document/d/18AJkthUSgu40QUYwQNdQ3B23SIFMVSU5HDr_5bVaCws/edit';
 
-const Steps = ({ candidateName, candidateEmail, currentDate, tlkio }) => {
-  const matchingRows = searchTiRows(candidateEmail).map(formatRow);
-  return (
-    <ol>
-      <li>Search for {candidateEmail || 'the candidate\'s email'} in the <a href={decisionsUrl} target="_blank">Form Responses</a> spreadsheet.</li>
-        <ul>Interviews scheduled by {candidateName.split(' ')[0] || 'candidate'} before 6/27/18: 
-          {matchingRows.length ? matchingRows.map(str => <li>{str}</li>) : ' None.'}
-        </ul>
-      <li>Choose the first prompt they haven't gotten under 'Prompt' below.</li>
-      <li>Open up a <a href={codestitchUrl} target="_blank">Codestitch</a> pad and paste the URL below.</li>
-      <li>Schedule a Zoom call named <i>{candidateName || 'FIRSTNAME LASTNAME'} - {currentDate}</i> and paste the join link below.</li>
-      <li>Go to <a href={tlkio} target="_blank">the tlk.io link</a> and conduct the interview using the script snippets below.</li>
-      <li>Move the completed prompt document from <a href={myDriveUrl} target="_blank">My Drive</a> to <a href={monthFoldersUrl} target="_blank">this month's folder</a>.</li>
-      <li>Fill out the <a href={tiDecisionsUrl} target="_blank">Technical Interview Decisions Form</a>.</li>
-      <li>If you have any questions, reference the <a href={tiWorkflowUrl} target="_blank">TI Workflow</a>.</li>
-    </ol>
-  );
-};
+const Steps = ({ candidateName, candidateEmail, currentDate, tlkio, staticTiRows }) => (
+  <ol>
+    <li>Search for {candidateEmail || 'the candidate\'s email'} in the <a href={decisionsUrl} target="_blank">Form Responses</a> spreadsheet.</li>
+      <ul>Interviews scheduled by {candidateName.split(' ')[0] || 'candidate'} before 6/27/18:
+        {staticTiRows.length ? staticTiRows.map(str => <li>{str}</li>) : ' None.'}
+      </ul>
+    <li>Choose the first prompt they haven't gotten under 'Prompt' below.</li>
+    <li>Open up a <a href={codestitchUrl} target="_blank">Codestitch</a> pad and paste the URL below.</li>
+    <li>Schedule a Zoom call named <i>{candidateName || 'FIRSTNAME LASTNAME'} - {currentDate}</i> and paste the join link below.</li>
+    <li>Go to <a href={tlkio} target="_blank">the tlk.io link</a> and conduct the interview using the script snippets below.</li>
+    <li>Move the completed prompt document from <a href={myDriveUrl} target="_blank">My Drive</a> to <a href={monthFoldersUrl} target="_blank">this month's folder</a>.</li>
+    <li>Fill out the <a href={tiDecisionsUrl} target="_blank">Technical Interview Decisions Form</a>.</li>
+    <li>If you have any questions, reference the <a href={tiWorkflowUrl} target="_blank">TI Workflow</a>.</li>
+  </ol>
+);
 
 export default Steps;

--- a/client/components/Steps.jsx
+++ b/client/components/Steps.jsx
@@ -5,12 +5,19 @@ const monthFoldersUrl = 'https://drive.google.com/drive/folders/0B5_RJCdGH93GdW1
 const tiDecisionsUrl = 'https://goo.gl/forms/IODn7sw3jtpiUq2n1';
 const tiWorkflowUrl = 'https://docs.google.com/document/d/18AJkthUSgu40QUYwQNdQ3B23SIFMVSU5HDr_5bVaCws/edit';
 
-const Steps = ({ candidateName, candidateEmail, currentDate, tlkio, staticTiRows }) => (
+const Steps = ({ candidateName, candidateEmail, currentDate, tlkio, staticTiRows, liveTiRows }) => (
   <ol>
     <li>Search for {candidateEmail || 'the candidate\'s email'} in the <a href={decisionsUrl} target="_blank">Form Responses</a> spreadsheet.</li>
-      <ul>Interviews scheduled by {candidateName.split(' ')[0] || 'candidate'} before 6/27/18:
-        {staticTiRows.length ? staticTiRows.map(str => <li>{str}</li>) : ' None.'}
-      </ul>
+      {staticTiRows ?
+        <ul>Interviews scheduled by {candidateName.split(' ')[0] || 'candidate'} before 6/27/18:
+          {staticTiRows.length ? staticTiRows.map(str => <li>{str}</li>) : ' None.'}
+        </ul>
+      : null }
+      {liveTiRows ?
+        <ul>Interviews scheduled since 6/27/18:
+          {liveTiRows.length ? liveTiRows.map(str => <li>{str}</li>) : ' None.'}
+        </ul>
+      : null}
     <li>Choose the first prompt they haven't gotten under 'Prompt' below.</li>
     <li>Open up a <a href={codestitchUrl} target="_blank">Codestitch</a> pad and paste the URL below.</li>
     <li>Schedule a Zoom call named <i>{candidateName || 'FIRSTNAME LASTNAME'} - {currentDate}</i> and paste the join link below.</li>

--- a/client/components/noteFns.js
+++ b/client/components/noteFns.js
@@ -1,4 +1,4 @@
-const moment = require('moment');
+import moment from 'moment';
 
 const countHP = text => {
   let autonomy = 0;
@@ -56,4 +56,4 @@ const formatNotes = (text, cursorLocation, relativeTimeStart) => {
   return splitText.join('\n');
 };
 
-module.exports = { countHP, formatNotes };
+export { countHP, formatNotes };

--- a/client/components/searchLiveTiHistory.js
+++ b/client/components/searchLiveTiHistory.js
@@ -1,0 +1,41 @@
+const moment = require('moment');
+
+const formatLiveTiRow = row => {
+  const unwrappedValues = row.map(cell => cell.formattedValue);
+  const time = moment(unwrappedValues[0], 'MM/DD/YYYY HH:mm:ss').format('MMMM Do YYYY');
+  const status = unwrappedValues[5];
+  const prompt = unwrappedValues[10];
+  return [time, status, prompt].filter(el => el).join(', ');
+};
+
+const processLiveTiData = (data, email) => {
+  const { result: { sheets: [sheet] } } = data;
+  const { data: [{ rowData : rows }]} = sheet;
+  // The sheet has a number of empty rows at the bottom,
+  // which .filter would needlessly iterate through.
+  const unformattedLiveTiRows = [];
+  for (let i = 0; i < rows.length; i++) {
+    const { values } = rows[i];
+    // Empty cells are empty objects, so we can't just check truthiness.
+    if (!Object.keys(values[0]).length) { // If we're past the filled rows
+      break;
+    }
+
+    const rowEmail = values[4].formattedValue;
+    if (rowEmail.trim() === email.trim()) { // No misleading whitespace
+      unformattedLiveTiRows.push(values);
+    }
+  }
+  return unformattedLiveTiRows.map(formatLiveTiRow);
+};
+
+const searchLiveTiHistory = async email => {
+  const path = 'https://sheets.googleapis.com/v4/spreadsheets/' +
+    '1ObVQGqm894fzjeM5vcG2qysYKDng4g8rtgyIwS3vJh8' +
+    '?ranges=%27Form%20Responses%27&includeGridData=true';
+  const data = await gapi.client.request({ path });
+  const liveTiRows = processLiveTiData(data, email);
+  return liveTiRows;
+}
+
+module.exports = searchLiveTiHistory;

--- a/client/components/searchLiveTiHistory.js
+++ b/client/components/searchLiveTiHistory.js
@@ -5,7 +5,9 @@ const formatLiveTiRow = row => {
   const time = moment(unwrappedValues[0], 'MM/DD/YYYY HH:mm:ss').format('MMMM Do YYYY');
   const status = unwrappedValues[5];
   const prompt = unwrappedValues[10];
-  return [time, status, prompt].filter(el => el).join(', ');
+  const reviewerRec = unwrappedValues[13] ? `Reviewer recommendation: ${unwrappedValues[13]}` : null;
+  return [time, status, prompt, reviewerRec]
+    .filter(el => el).join(', '); // el => el avoids empty cells being included in the string
 };
 
 const processLiveTiData = (data, email) => {

--- a/client/components/searchLiveTiHistory.js
+++ b/client/components/searchLiveTiHistory.js
@@ -11,21 +11,12 @@ const formatLiveTiRow = row => {
 const processLiveTiData = (data, email) => {
   const { result: { sheets: [sheet] } } = data;
   const { data: [{ rowData : rows }]} = sheet;
-  // The sheet has a number of empty rows at the bottom,
-  // which .filter would needlessly iterate through.
-  const unformattedLiveTiRows = [];
-  for (let i = 0; i < rows.length; i++) {
-    const { values } = rows[i];
-    // Empty cells are empty objects, so we can't just check truthiness.
-    if (!Object.keys(values[0]).length) { // If we're past the filled rows
-      break;
-    }
-
-    const rowEmail = values[4].formattedValue;
-    if (rowEmail.trim() === email.trim()) { // No misleading whitespace
-      unformattedLiveTiRows.push(values);
-    }
-  }
+  const unformattedLiveTiRows = rows.map(({ values }) => values).filter(values => {
+    const { formattedValue: rowEmail } = values[4];
+    // rowEmail && avoids problems with the many empty rows at the bottom of the sheet.
+    // Each cell in an empty row is {}, so rowEmail is undefined and .trim() would error.
+    return rowEmail && rowEmail.trim() === email.trim(); // Remove misleading whitespace
+  });
   return unformattedLiveTiRows.map(formatLiveTiRow);
 };
 

--- a/client/components/searchLiveTiHistory.js
+++ b/client/components/searchLiveTiHistory.js
@@ -1,4 +1,4 @@
-const moment = require('moment');
+import moment from 'moment';
 
 const formatLiveTiRow = row => {
   const unwrappedValues = row.map(cell => cell.formattedValue);
@@ -31,4 +31,4 @@ const searchLiveTiHistory = async email => {
   return liveTiRows;
 }
 
-module.exports = searchLiveTiHistory;
+export default searchLiveTiHistory;

--- a/client/components/searchStaticTiHistory.js
+++ b/client/components/searchStaticTiHistory.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import staticTiHistory from '../../staticTiHistory.js';
+import staticTiHistory from '../../staticTiHistory';
 
 const tiRows = staticTiHistory.split('\n').map(row => row.split(','));
 const searchTiRows = email => tiRows
@@ -10,4 +10,5 @@ const formatRow = row => {
   return [formattedTime, status, prompt].filter(el => el).join(', ');
 };
 
-module.exports = email => searchTiRows(email).map(formatRow);
+const searchStaticTiHistory = email => searchTiRows(email).map(formatRow);
+export default searchStaticTiHistory;

--- a/client/components/searchStaticTiHistory.js
+++ b/client/components/searchStaticTiHistory.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import staticTiHistory from '../../staticTiHistory.js';
 
 const tiRows = staticTiHistory.split('\n').map(row => row.split(','));

--- a/client/components/searchStaticTiHistory.js
+++ b/client/components/searchStaticTiHistory.js
@@ -1,0 +1,12 @@
+import staticTiHistory from '../../staticTiHistory.js';
+
+const tiRows = staticTiHistory.split('\n').map(row => row.split(','));
+const searchTiRows = email => tiRows
+  .filter(([, rowEmail]) => rowEmail === (email || null)); // Avoid match on missing emails
+const formatRow = row => {
+  const [, , time, status, prompt] = row;
+  const formattedTime = moment(time).format('MMMM Do YYYY');
+  return [formattedTime, status, prompt].filter(el => el).join(', ');
+};
+
+module.exports = email => searchTiRows(email).map(formatRow);


### PR DESCRIPTION
Two major updates in this pull request:
1. On login, the app pulls the active decisions spreadsheet (which contains interview records since 6/27/18) and displays the dates, prompts, and results of any previous interviews by the candidate. It also suggests which of the prompts to use based on that information.
2. When the user chooses a prompt, the app automatically finds the current month's interview records folder and places the prompt copy there.

Non-functional changes:
1. Moving search of static TI file into its own component (from Steps).
2. Changing the Steps script to reflect the new workflow.