### PR TITLE
Correctly parse newer formatted calendar event

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -12,6 +12,7 @@ import {
   apiKey,
   clientId,
   interviewsTitlePrefix,
+  interviewsNewMetadata,
   interviewMonthsFolderId,
   interviewMonthFolderName,
   prompts,
@@ -37,6 +38,26 @@ class App extends Component {
     staticTiRows: null,
     liveTiRows: null,
     zoomToken: '',
+  };
+
+  static getInterviewDetails = (description) => {
+    const FIRST_IDX = 5;
+    const LAST_IDX = 6;
+    const EMAIL_IDX = 7;
+    const CHAT_IDX = 3;
+
+    // Determine whether the interview is based on the newer format
+    const isNewer = description.indexOf(interviewsNewMetadata) >= 0;
+
+    if (isNewer) {
+      const soonestInterviewDetails = description.split('\n');
+      const parseResults = description.split('\n').map(el => el.split(': ')[1]);
+      return [`${parseResults[FIRST_IDX]} ${parseResults[LAST_IDX]}`,
+        parseResults[EMAIL_IDX], parseResults[CHAT_IDX]];
+    } else {
+      const soonestInterviewDetails = description.split('\n').slice(0, 3);
+      return soonestInterviewDetails.map(el => el.split(': ')[1]);
+    }
   };
 
   componentDidMount() {
@@ -155,8 +176,8 @@ class App extends Component {
         },
       });
       const { description, start: { dateTime } } = interview;
-      const soonestInterviewDetails = description.split('\n').slice(0, 3);
-      const [candidateName, candidateEmail, tlkioLink] = soonestInterviewDetails.map(el => el.split(': ')[1]);
+      const [candidateName, candidateEmail, tlkioLink] = App.getInterviewDetails(description);
+
       const startTime = moment(dateTime);
       this.setState({
         startTime,

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -12,7 +12,6 @@ import {
   apiKey,
   clientId,
   interviewsTitlePrefix,
-  interviewsNewMetadata,
   interviewMonthsFolderId,
   interviewMonthFolderName,
   prompts,
@@ -42,11 +41,11 @@ class App extends Component {
 
   static getInterviewDetails = (description) => {
     // Determine whether the interview is based on the newer format
-    const isNewer = description.includes(interviewsNewMetadata) >= 0;
+    const isNewer = description.includes('YCBM link ref');
 
     if (isNewer) {
       const parsedResults = description.split('\n').map(el => el.split(': ')[1]);
-	  const candidateName = `${parsedResults[5]} ${parsedResults[6]}`;
+      const candidateName = `${parsedResults[5]} ${parsedResults[6]}`;
       const candidateEmail = parsedResults[7];
       const tlkioLink = parsedResults[3];
 

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -41,19 +41,16 @@ class App extends Component {
   };
 
   static getInterviewDetails = (description) => {
-    const FIRST_IDX = 5;
-    const LAST_IDX = 6;
-    const EMAIL_IDX = 7;
-    const CHAT_IDX = 3;
-
     // Determine whether the interview is based on the newer format
-    const isNewer = description.indexOf(interviewsNewMetadata) >= 0;
+    const isNewer = description.includes(interviewsNewMetadata) >= 0;
 
     if (isNewer) {
-      const soonestInterviewDetails = description.split('\n');
-      const parseResults = description.split('\n').map(el => el.split(': ')[1]);
-      return [`${parseResults[FIRST_IDX]} ${parseResults[LAST_IDX]}`,
-        parseResults[EMAIL_IDX], parseResults[CHAT_IDX]];
+      const parsedResults = description.split('\n').map(el => el.split(': ')[1]);
+	  const candidateName = `${parsedResults[5]} ${parsedResults[6]}`;
+      const candidateEmail = parsedResults[7];
+      const tlkioLink = parsedResults[3];
+
+      return [candidateName, candidateEmail, tlkioLink];
     } else {
       const soonestInterviewDetails = description.split('\n').slice(0, 3);
       return soonestInterviewDetails.map(el => el.split(': ')[1]);


### PR DESCRIPTION
Calendar events for interviews now follow a different format for the event description. This PR allows events of the newer and older formats to be properly parsed.

Since the metadata being searched is more sensitive, a new variable is now imported from config.js, so anyone who uses ViewFinder now needs to make sure their config.js has that new variable.